### PR TITLE
Trying a different variation of the noarch builds

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,3 +6,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -11,4 +11,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
   sha256: edbb08b561feda505374c0f25e4b54466a0a0c702ed6b2efaabdc3890d1a82e7
 
 build:
-  number: 1
+  noarch: python
+  number: 2
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
@@ -20,7 +21,7 @@ requirements:
   - python >=3.6
   - pip
   run:
-  - python >=3.6
+  - python 
   - dataclasses >=0.6  # [py36]
 
 test:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I think the issue comes from pinning Python in the Host and the Run section,
which appears to cause a conflict in building the package such that the
package itself cannot be found.

I'm basing this PR on my local testing and what I am seeing from the
rpcq-feedstock which appears to be the only other package which
uses the dataclasses package on conda-forge and builds on noarch.
Or, at least, they did.

Possible replacement to \#4, but experimental.

@conda-forge-admin, please rerender