### PR TITLE
Add abi_migration_branches for `1.x` to conda-forge.yml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -15,3 +15,5 @@ conda_build:
   pkg_format: '2'
 bot:
   inspection: update-grayskull
+  abi_migration_branches:
+    - '1.x'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
All branches on the feedstock will trigger a release. To have migrations for a branch, we need to list it on main in `conda-forge.yml`.

Relevant discussion: https://github.com/conda-forge/pydantic-feedstock/pull/107

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
